### PR TITLE
fix: refactoring the code

### DIFF
--- a/php/v2/ReturnOperation.php
+++ b/php/v2/ReturnOperation.php
@@ -2,138 +2,202 @@
 
 namespace NW\WebService\References\Operations\Notification;
 
-class TsReturnOperation extends ReferencesOperation
-{
-    public const TYPE_NEW    = 1;
+use Exception;
+
+class TsReturnOperation extends ReferencesOperation {
+    public const TYPE_NEW = 1;
     public const TYPE_CHANGE = 2;
 
+    public const EMAILS_TYPE_PERMITTED = 'tsGoodsReturn';
+    
     /**
-     * @throws \Exception
+     * @throws Exception
      */
-    public function doOperation(): void
-    {
-        $data = (array)$this->getRequest('data');
+    public function doOperation(): array {
+        $notificationEmployeeByEmail = false;
+        $notificationClientByEmail = false;
+        $notificationClientBySmsIsSent = false;
+        $sendMobileErrMessage = '';
+        
+        $data = $this->getDataFromRequest();
         $resellerId = $data['resellerId'];
-        $notificationType = (int)$data['notificationType'];
-        $result = [
-            'notificationEmployeeByEmail' => false,
-            'notificationClientByEmail'   => false,
-            'notificationClientBySms'     => [
-                'isSent'  => false,
-                'message' => '',
-            ],
-        ];
-
-        if (empty((int)$resellerId)) {
-            $result['notificationClientBySms']['message'] = 'Empty resellerId';
-            return $result;
+        $creatorId = $data['creatorId'];
+        $clientId = $data['clientId'];
+        $expertId = $data['expertId'];
+        $notificationType = $data['notificationType'];
+        
+        $client = Contractor::getById($clientId);
+        if (is_null($client)) {
+            throw new Exception('Client not found!', 400);
         }
-
-        if (empty((int)$notificationType)) {
-            throw new \Exception('Empty notificationType', 400);
+        if ($client->type !== Contractor::TYPE_CUSTOMER) {
+            throw new Exception('Client no valid type!', 400);
         }
-
-        $reseller = Seller::getById((int)$resellerId);
-        if ($reseller === null) {
-            throw new \Exception('Seller not found!', 400);
+        $seller = Seller::getById($clientId);
+        if(!is_null($seller)){
+            throw new Exception('The client is a seller!', 400);
         }
-
-        $client = Contractor::getById((int)$data['clientId']);
-        if ($client === null || $client->type !== Contractor::TYPE_CUSTOMER || $client->Seller->id !== $resellerId) {
-            throw new \Exception('сlient not found!', 400);
+        $cr = Employee::getById($creatorId);
+        if (is_null($cr)) {
+            throw new Exception('Creator not found!', 400);
         }
-
-        $cFullName = $client->getFullName();
-        if (empty($client->getFullName())) {
-            $cFullName = $client->name;
+        $et = Employee::getById($expertId);
+        if (is_null($et)) {
+            throw new Exception('Expert not found!', 400);
         }
-
-        $cr = Employee::getById((int)$data['creatorId']);
-        if ($cr === null) {
-            throw new \Exception('Creator not found!', 400);
-        }
-
-        $et = Employee::getById((int)$data['expertId']);
-        if ($et === null) {
-            throw new \Exception('Expert not found!', 400);
-        }
-
-        $differences = '';
-        if ($notificationType === self::TYPE_NEW) {
-            $differences = __('NewPositionAdded', null, $resellerId);
-        } elseif ($notificationType === self::TYPE_CHANGE && !empty($data['differences'])) {
-            $differences = __('PositionStatusHasChanged', [
-                    'FROM' => Status::getName((int)$data['differences']['from']),
-                    'TO'   => Status::getName((int)$data['differences']['to']),
-                ], $resellerId);
-        }
-
-        $templateData = [
-            'COMPLAINT_ID'       => (int)$data['complaintId'],
-            'COMPLAINT_NUMBER'   => (string)$data['complaintNumber'],
-            'CREATOR_ID'         => (int)$data['creatorId'],
-            'CREATOR_NAME'       => $cr->getFullName(),
-            'EXPERT_ID'          => (int)$data['expertId'],
-            'EXPERT_NAME'        => $et->getFullName(),
-            'CLIENT_ID'          => (int)$data['clientId'],
-            'CLIENT_NAME'        => $cFullName,
-            'CONSUMPTION_ID'     => (int)$data['consumptionId'],
-            'CONSUMPTION_NUMBER' => (string)$data['consumptionNumber'],
-            'AGREEMENT_NUMBER'   => (string)$data['agreementNumber'],
-            'DATE'               => (string)$data['date'],
-            'DIFFERENCES'        => $differences,
-        ];
-
-        // Если хоть одна переменная для шаблона не задана, то не отправляем уведомления
-        foreach ($templateData as $key => $tempData) {
-            if (empty($tempData)) {
-                throw new \Exception("Template Data ({$key}) is empty!", 500);
-            }
-        }
-
-        $emailFrom = getResellerEmailFrom($resellerId);
-        // Получаем email сотрудников из настроек
-        $emails = getEmailsByPermit($resellerId, 'tsGoodsReturn');
+        
+        $data['creatorName'] = $cr->getFullName();
+        $data['expertName'] = $et->getFullName();
+        $templateData = $this->getTemplate($data);
+    
+        $emailFrom = getResellerEmailFrom();
+        $emails = getEmailsByPermit($resellerId, self::EMAILS_TYPE_PERMITTED);
+        
         if (!empty($emailFrom) && count($emails) > 0) {
+            $messageEmail = [
+                'emailFrom' => $emailFrom,
+                'subject' => __('complaintEmployeeEmailSubject', $templateData),
+                'message' => __('complaintEmployeeEmailBody', $templateData),
+            ];
             foreach ($emails as $email) {
-                MessagesClient::sendMessage([
-                    0 => [ // MessageTypes::EMAIL
-                           'emailFrom' => $emailFrom,
-                           'emailTo'   => $email,
-                           'subject'   => __('complaintEmployeeEmailSubject', $templateData, $resellerId),
-                           'message'   => __('complaintEmployeeEmailBody', $templateData, $resellerId),
-                    ],
-                ], $resellerId, NotificationEvents::CHANGE_RETURN_STATUS);
-                $result['notificationEmployeeByEmail'] = true;
-
+                $messageEmail['emailTo'] = $email;
+                MessagesClient::sendMessage(
+                    [MessageTypes::EMAIL => $messageEmail],
+                    $resellerId,
+                    $client->id, // здесь не хватает параметра или в следующем вызове он лишний
+                    NotificationEvents::CHANGE_RETURN_STATUS
+                );
             }
+            $notificationEmployeeByEmail = true;
         }
 
-        // Шлём клиентское уведомление, только если произошла смена статуса
+        /** Шлём клиентское уведомление, только если произошла смена статуса */
         if ($notificationType === self::TYPE_CHANGE && !empty($data['differences']['to'])) {
             if (!empty($emailFrom) && !empty($client->email)) {
-                MessagesClient::sendMessage([
-                    0 => [ // MessageTypes::EMAIL
-                           'emailFrom' => $emailFrom,
-                           'emailTo'   => $client->email,
-                           'subject'   => __('complaintClientEmailSubject', $templateData, $resellerId),
-                           'message'   => __('complaintClientEmailBody', $templateData, $resellerId),
-                    ],
-                ], $resellerId, $client->id, NotificationEvents::CHANGE_RETURN_STATUS, (int)$data['differences']['to']);
-                $result['notificationClientByEmail'] = true;
+                $messageEmail = [
+                    'emailFrom' => $emailFrom,
+                    'emailTo' => $client->email,
+                    'subject' => __('complaintClientEmailSubject', $templateData),
+                    'message' => __('complaintClientEmailBody', $templateData),
+                ];
+                
+                MessagesClient::sendMessage(
+                    [MessageTypes::EMAIL => $messageEmail],
+                    $resellerId,
+                    $client->id, // здесь лишний параметр или в предыдущем вызове его не хватает
+                    NotificationEvents::CHANGE_RETURN_STATUS,
+                    $data['differences']['to']
+                );
+                $notificationClientByEmail = true;
             }
 
             if (!empty($client->mobile)) {
-                $res = NotificationManager::send($resellerId, $client->id, NotificationEvents::CHANGE_RETURN_STATUS, (int)$data['differences']['to'], $templateData, $error);
-                if ($res) {
-                    $result['notificationClientBySms']['isSent'] = true;
-                }
+                $error = null;
+                $notificationClientBySmsIsSent = NotificationManager::send(
+                    $resellerId,
+                    $client->id,
+                    NotificationEvents::CHANGE_RETURN_STATUS,
+                    $data['differences']['to'],
+                    $templateData,
+                    $error
+                );
+                
                 if (!empty($error)) {
-                    $result['notificationClientBySms']['message'] = $error;
+                    $sendMobileErrMessage = $error;
                 }
             }
         }
-
-        return $result;
+        
+        return [
+            'notificationEmployeeByEmail' => $notificationEmployeeByEmail,
+            'notificationClientByEmail' => $notificationClientByEmail,
+            'notificationClientBySms' => [
+                'isSent' => $notificationClientBySmsIsSent,
+                'error' => $sendMobileErrMessage,
+            ],
+        ];
+    }
+    
+    
+    /**
+     * @return array<mixed> $data
+     * @throws Exception
+     */
+    private function getDataFromRequest(): array {
+        $data = $this->getRequest('data');
+        $validationData = new Validation($this->getFieldsRules(), $data);
+        return $validationData->validate();
+    }
+    
+    /**
+     * @param array<mixed> $data
+     * @return array<mixed>
+     * @throws Exception
+     */
+    private function getTemplate(array $data): array {
+        $differences = '';
+        $notificationType = $data['notificationType'];
+        if ($notificationType === self::TYPE_NEW) {
+            $differences = __('NewPositionAdded');
+        } elseif ($notificationType === self::TYPE_CHANGE && isset($data['differences'])) {
+            $from = Status::getName($data['differences']['from']);
+            $to = Status::getName($data['differences']['to']);
+            if (!empty($from) && !empty($to)) {
+                $differences = __('PositionStatusHasChanged', [
+                    'FROM' => $from,
+                    'TO' => $to,
+                ]);
+            }
+        }
+        
+        $templateData = [
+            'COMPLAINT_ID' => $data['complaintId'],
+            'COMPLAINT_NUMBER' => $data['complaintNumber'],
+            'CREATOR_ID' => $data['creatorId'],
+            'CREATOR_NAME' => $data['creatorName'],
+            'EXPERT_ID' => $data['expertId'],
+            'EXPERT_NAME' => $data['expertName'],
+            'CLIENT_ID' => $data['clientId'],
+            'CLIENT_NAME' => $data['clientName'],
+            'CONSUMPTION_ID' => $data['consumptionId'],
+            'CONSUMPTION_NUMBER' => $data['consumptionNumber'],
+            'AGREEMENT_NUMBER' => $data['agreementNumber'],
+            'DATE' => $data['date'],
+            'DIFFERENCES' => $differences,
+        ];
+        
+        /** Если хоть одна переменная для шаблона не задана, то не отправляем уведомления */
+        $emptyKeys = [];
+        foreach ($templateData as $key => $tempData) {
+            if (empty($tempData)) {
+                $emptyKeys[] = $key;
+            }
+        }
+        if ($emptyKeys) {
+            throw new Exception(sprintf('Empty template data: %s', implode(', ', $emptyKeys)), 500);
+        }
+        return $templateData;
+    }
+    
+    /**
+     * @return array<string, array{req: ?bool,type: ?string, match: ?string}>
+     */
+    private function getFieldsRules(): array {
+        return [
+            'complaintId' => ['req' => true, 'type' => 'int'],
+            'complaintNumber' => ['req' => true, 'type' => 'string', 'match' => '^[\w\d_-$]+$'],
+            'creatorId' => ['req' => true, 'type' => 'int'],
+            'creatorName' => ['req' => true, 'type' => 'string'],
+            'expertId' => ['req' => true, 'type' => 'int'],
+            'expertName' => ['req' => true, 'type' => 'string'],
+            'clientId' => ['req' => true, 'type' => 'int'],
+            'clientName' => ['req' => true, 'type' => 'string'],
+            'consumptionId' => ['req' => true, 'type' => 'int'],
+            'consumptionNumber' => ['req' => true, 'type' => 'string', 'match' => '^[\w\d_-$]+$'],
+            'agreementNumber' => ['req' => true, 'type' => 'string', 'match' => '^[\w\d_-$]+$'],
+            'date' => ['req' => true, 'type' => 'string', 'match' => '^\d{4}-\d{2}-\d{2}$'],
+            'differences.from' => ['req' => true, 'type' => 'int'],
+            'differences.to' => ['req' => true, 'type' => 'int'],
+        ];
     }
 }

--- a/php/v2/others.php
+++ b/php/v2/others.php
@@ -271,3 +271,85 @@ class SendingResult extends Result {
         return $this->isSuccess() && $this->isSenderSuccess;
     }
 }
+
+
+interface EmailServiceInterface
+{
+    public function sendMessage(
+        array $message,
+        int $resellerId,
+        int $clientId,
+        int $notificationType,
+        int $differencesTo = 0
+    ): void;
+
+}
+
+interface SmsServiceInterface
+{
+    public function send(
+        int $resellerId,
+        int $clientId,
+        int $notificationType,
+        int $differencesTo,
+        array $templateMessageData,
+        string &$error
+    ): void;
+}
+
+class SmsService implements SmsServiceInterface
+{
+    /**
+     * @param int    $resellerId
+     * @param int    $clientId
+     * @param int    $notificationType
+     * @param int    $differencesTo
+     * @param array  $templateMessageData
+     * @param string $error
+     * @return void
+     */
+    public function send(
+        int $resellerId,
+        int $clientId,
+        int $notificationType,
+        int $differencesTo,
+        array $templateMessageData,
+        string &$error
+    ): void {
+        NotificationManager::send(
+            $this->resellerId,
+            $this->client->id,
+            $this->notificationType,
+            $this->differencesTo,
+            $this->templateMessageData,
+            $error
+        );
+    }
+}
+
+
+class EmailService implements EmailServiceInterface
+{
+    /**
+     * @param array $message
+     * @param int   $resellerId
+     * @param int   $clientId
+     * @param int   $notificationType
+     * @param int   $differencesTo
+     * @return void
+     */
+    public function sendMessage(
+        array $message,
+        int $resellerId,
+        int $clientId,
+        int $notificationType,
+        int $differencesTo = 0
+    ): void {
+        MessagesClient::sendMessage(
+            [MessageTypes::EMAIL => $message],
+            $this->resellerId,
+            $this->client->id,
+            $this->notificationType,
+        );
+    }
+}

--- a/php/v2/others.php
+++ b/php/v2/others.php
@@ -2,74 +2,196 @@
 
 namespace NW\WebService\References\Operations\Notification;
 
-/**
- * @property Seller $Seller
- */
-class Contractor
-{
-    const TYPE_CUSTOMER = 0;
-    public $id;
-    public $type;
-    public $name;
+use Exception;
 
-    public static function getById(int $resellerId): self
-    {
-        return new self($resellerId); // fakes the getById method
+class Contractor {
+    public const TYPE_CUSTOMER = 0;
+    public const TYPE_SELLER = 1;
+    public const TYPE_EMPLOYEE = 2;
+    public int $id;
+    public int $type;
+    public string $name;
+
+    public function __construct(int $resellerId) {
+        $this->id = $resellerId;
+        $this->type = self::TYPE_CUSTOMER;
+        $this->name = '';
+    }
+    
+    public static function getById(int $resellerId): ?static {
+        return new static($resellerId); // fakes the getById method
     }
 
-    public function getFullName(): string
-    {
-        return $this->name . ' ' . $this->id;
+    public function getFullName(): string {
+        return ($this->name ? $this->name . ' ' : '') . $this->id;
     }
 }
 
-class Seller extends Contractor
-{
+class Seller extends Contractor {
+    public function __construct(int $resellerId) {
+        parent::__construct($resellerId);
+        $this->type = self::TYPE_SELLER;
+    }
 }
 
-class Employee extends Contractor
-{
+class Employee extends Contractor {
+    public function __construct(int $resellerId) {
+        parent::__construct($resellerId);
+        $this->type = self::TYPE_EMPLOYEE;
+    }
 }
 
-class Status
-{
-    public $id, $name;
+class Status {
+    public const COMPLETED = 0;
+    public const PENDING = 1;
+    public const REJECTED = 2;
+    public int $id;
+    public string $name;
 
-    public static function getName(int $id): string
-    {
+    public static function getName(int $id): ?string {
         $a = [
-            0 => 'Completed',
-            1 => 'Pending',
-            2 => 'Rejected',
+            self::COMPLETED => 'Completed',
+            self::PENDING => 'Pending',
+            self::REJECTED => 'Rejected',
         ];
 
-        return $a[$id];
+        return $a[$id] ?? null;
     }
 }
 
-abstract class ReferencesOperation
-{
+abstract class ReferencesOperation {
+    /**
+     * @return array{
+     * notificationEmployeeByEmail:bool,
+     * notificationClientByEmail:bool,
+     * notificationClientBySms: array{isSent:bool, error: string}
+     * }
+     */
     abstract public function doOperation(): array;
 
-    public function getRequest($pName)
-    {
-        return $_REQUEST[$pName];
+    public function getRequest($pName): mixed {
+        return $_REQUEST[$pName] ?? null;
     }
 }
 
-function getResellerEmailFrom()
-{
+function getResellerEmailFrom(): string {
     return 'contractor@example.com';
 }
 
-function getEmailsByPermit($resellerId, $event)
-{
+function getEmailsByPermit(int $resellerId, string $event): array {
     // fakes the method
     return ['someemeil@example.com', 'someemeil2@example.com'];
 }
 
-class NotificationEvents
-{
-    const CHANGE_RETURN_STATUS = 'changeReturnStatus';
-    const NEW_RETURN_STATUS    = 'newReturnStatus';
+
+class NotificationEvents {
+    public const CHANGE_RETURN_STATUS = 'changeReturnStatus';
+    public const NEW_RETURN_STATUS = 'newReturnStatus';
+}
+
+class Validation {
+    /**
+     * @param array<string,array{req: ?bool,type: ?string, match: ?string}> $fieldRules
+     * @param array<string,array{mixed}> $fieldData
+     */
+    public function __construct(private readonly array $fieldRules, private array $fieldData) {
+    }
+    
+    /**
+     * @throws Exception
+     */
+    private function validateField(string $fieldName): void {
+        try {
+            $arrKeys = explode('.', $fieldName);
+            $value = &$this->fieldData;
+            foreach ($arrKeys as $key) {
+                if (isset($value[$key])) {
+                    $value = &$value[$key];
+                } else {
+                    unset($value);
+                    break;
+                }
+            }
+            $field = $this->fieldRules[$fieldName];
+            if (!isset($value)) {
+                if ($field['req']) {
+                    throw new Exception("Field $fieldName not found.");
+                }
+            } else {
+                $value = $this->castValue($fieldName, $value);
+                $this->matchValue($fieldName, $value);
+            }
+        } finally {
+            unset($value);
+        }
+    }
+    
+    /**
+     * @return array<mixed>
+     * @throws Exception
+     */
+    public function validate(): array {
+        if (!is_array($this->fieldRules)) {
+            throw new Exception('Field rules is not array');
+        }
+        if (!is_array($this->fieldData)) {
+            throw new Exception('Field data is not array');
+        }
+        $fields = $this->fieldRules;
+        foreach ($fields as $key => $field) {
+            $this->validateField($key);
+        }
+        
+        return $this->fieldData;
+    }
+    
+    /**
+     * @throws Exception
+     */
+    private function matchValue(string $fieldName, mixed $value): void {
+        $rules = $this->fieldRules[$fieldName];
+        $type = $rules['type'];
+        $match = $rules['match'] ?? '';
+    
+        if (empty($match) || $type !== 'string') {
+            return;
+        }
+        
+        if (!preg_match($match, $value)) {
+            throw new Exception("Value field '{$fieldName}' not match '{$match}'");
+        }
+    }
+    
+    /**
+     * @throws Exception
+     */
+    private function castValue(string $fieldName, mixed $value): int|string {
+        $rules = $this->fieldRules[$fieldName];
+        $type = $rules['type'];
+        $req = $rules['req'];
+        
+        if (empty($type)) {
+            return $value;
+        }
+        
+        switch ($type) {
+            case 'int':
+                if (is_numeric($value)) {
+                    $value = (int)$value;
+                    if (!$req || $value !== 0) {
+                        return $value;
+                    }
+                }
+                break;
+            case 'string':
+                if (is_string($value)) {
+                    $value = (string)$value;
+                    if (!$req || $value !== '') {
+                        return $value;
+                    }
+                }
+                break;
+        }
+        throw new Exception("Value is not type '{$type}'");
+    }
 }


### PR DESCRIPTION
file others.php
изменил немного методы и классы в файле чтобы код был более логичен и связан с кодом  в файле TsReturnOperation
1. добавил недостающие типы в классе Contractor
2. изменил сигнатуру и реализацию метода Contractor::getById чтобы при вызове из производных классов он возвращал объект производного класса, а не базового.
3. добавил класс Validation для валидации и типизации полей, данной роли не должно быть в классе TsReturnOperation
4. добавил типизацию методам и их параметрам

file TsReturnOperation.php
основная задача класса, получить данные из реквеста и отправить сообщения, клиенту на почту и/или телефон ,сотрудникам на почту. Причем сырые дынные из реквеста подставлялись в шаблон, что является потенциальной угрозой как sql-инъекций так и внедрением в шаблон скриптов которые могут быть запущены на устройствах получателей.

Изначально в методе было много ролей: получить данные из реквеста, провалидировать их и привести к нужным типам. На основе этих данных заполнить шаблон, провалидировать его и отправить данные по нескольким каналам и  адресатам.
После рефакторинга удалось вынести роли работы с данными из реквеста в отдельный класс, заполнение и валидацию шаблона в отдельный метод. В разные методы были перенесены  отправки сообщений.

Код `$client->Seller->id` скорее всего ошибочен, так как клиент не обладает таким параметром, скорее всего имелась ввиду проверка на то что клиент не является продавцом, код был заменен `$seller = Seller::getById($clientId);` 

В цикле ` foreach ($emails as $email) `  на каждый email создавался новый шаблон с сообщением, хотя изменялся только получатель,  создание шаблона было установлено перед циклом, в цикле менялся только получатель. 

Есть проблема с функцией MessagesClient::sendMessage, есть два ее вызова с разным набором параметров,  в первом вызове перед параметром со значением `NotificationEvents::CHANGE_RETURN_STATUS` нет `$client->id`? в Следующем вызове этот параметр присутствует, явно ошибка вызова будет, если у этой функции есть типизация параметров,  или она будет работать неверно если типизации нет. 
 Еще одна проблема в том, что эта функция принимает много параметров, которых по названию функции у нее не должно быть, скорее всего у нее так же много ролей, и хорошо бы ее тоже отрефакторить.

Функция __() скорее всего из ларавел, используется для локализации и третий параметр должен быть доступной локалью или пустым, чтобы подставлялась текущая локалью. Но даже если предположить, что третий параметр должен использовать локаль получателя сообщения, а не локаль посредника указанного в $resellerId, все равно будет неверное поведение функции.

К функции NotificationManager::send такие же претензии как и MessagesClient::sendMessage, слишком много параметров, да еще и передается не итоговое сообщение, а массив с данными. Так же у этой функции ошибки передаются через параметр $error, переданный по ссылке. Обеим этим функциям  надо изменить тип возвращаемого параметра, пусть это будет объект Result, с методами определяющим, что  функция отработал успешно и метод  возвращающий  коллекцию ошибок. Тогда можно было бы в функции возвращать массив
 `
[
  'notificationEmployeeByEmail' => $ResultEmployeeEmail,
  'notificationClientByEmail' => $ResultClientEmaill,
  'notificationClientBySms' => $ResultMobileClientEmaill,
]
`
если нужно возвращать дополнительные данные, их можно поместить в объект через функцию SetData

Добавил метод возвращающий поля из реквеста и их настройки, он позволяет легче добавлять новые поля, определять их тип и валидацию.

Через конструктор класса TsReturnOperation, с помощью DI, будут переданы реализации интерфейсов для отправки смс и писем. Что так же уменьшит связанность данного класса с конкретными реализациями отправки сообщений.